### PR TITLE
Check for non-nil match in S0039

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -296,10 +296,13 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
     has_503 = File.foreach(logfile).any? do |line|
       match = line.match(apache_regex)
-      time  = Time.strptime(match[:time], '[%d/%b/%Y:%H:%M:%S %Z]')
+      next unless match && match[:time] && match[:status]
+
+      time = Time.strptime(match[:time], '[%d/%b/%Y:%H:%M:%S %Z]')
       since_lastrun = Time.now - time
       current = since_lastrun.to_i <= Puppet.settings['runinterval']
-      match and match[:status] == '503' and current
+
+      match[:status] == '503' and current
     end
 
     { S0039: !has_503 }


### PR DESCRIPTION
Prior to this commit, S0039 could fail if a line in the access log was
not in common log format, which would result in [] being called on a nil
object.  This commit checks that we have a match, as well as the named
capture groups.