### PR TITLE
(SUP-3122) Fix PSQL node detection in 2021.5

### DIFF
--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -155,8 +155,7 @@ module PEStatusCheck
     !service_file_exist?('pe-puppetserver') &&
       !service_file_exist?('pe-orchestration-services') &&
       !service_file_exist?('pe-console-services') &&
-      !service_file_exist?('pe-puppetdb') &&
-      service_file_exist?('pe-pgsql/pe-postgresql')
+      !service_file_exist?('pe-puppetdb')
   end
 
   # Get the free disk percentage from a path


### PR DESCRIPTION
Prior to this commit the presence of the service file "/pe-pgsql/pe-postgresql" was considered in the determination of the node type, in 2021.5 this service file does not exist.

PSQL nodes are now simply a negative check for the other node types