### PR TITLE
(SUP-3315) Use cached state to determine node role

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -201,7 +201,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
   chunk(:S0022) do
     # Is there a valid license present, which does not expire in 90 days
     # Also takes into account if the license type is Perpetual
-    next unless PEStatusCheck.primary?
+    next unless ['primary'].include?(Facter.value('pe_status_check_role'))
+
     license_file = '/etc/puppetlabs/license.key'
     if File.exist?(license_file)
       begin

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -4,6 +4,9 @@
 Facter.add(:pe_status_check, type: :aggregate) do
   confine kernel: 'Linux'
   confine { Facter.value(:pe_build) }
+  confine 'pe_status_check_role' do |pe_status_check_role|
+    pe_status_check_role != 'unknown'
+  end
   require 'puppet'
   require 'yaml'
   require_relative '../shared/pe_status_check'
@@ -25,7 +28,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0004) do
     # Are All Services running
-    next unless ['primary', 'replica', 'pe_compiler', 'compiler'].include?(Facter.value('pe_status_check_role'))
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
 
     response = PEStatusCheck.http_get('/status/v1/services', 8140)
     if response

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -25,7 +25,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0004) do
     # Are All Services running
-    next unless PEStatusCheck.primary? || PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler?
+    next unless ['primary', 'replica', 'pe_compiler', 'compiler'].include?(Facter.value('pe_status_check_role'))
 
     response = PEStatusCheck.http_get('/status/v1/services', 8140)
     if response
@@ -42,25 +42,23 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0005) do
     # Is the CA expiring in the next 90 days
-    next unless File.exist?('/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem') || File.exist?('/etc/puppetlabs/puppetserver/ca/ca_crt.pem')
-    raw_ca_cert = if File.exist? '/etc/puppetlabs/puppetserver/ca/ca_crt.pem'
-                    File.read '/etc/puppetlabs/puppetserver/ca/ca_crt.pem'
-                  else
-                    File.read '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem'
-                  end
-    certificate = OpenSSL::X509::Certificate.new raw_ca_cert
-    result = certificate.not_after - Time.now
-    { S0005: result > 7_776_000 }
+    cacert = Puppet.settings[:cacert]
+    next unless File.exist?(cacert)
+
+    x509_cert = OpenSSL::X509::Certificate.new(File.read(cacert))
+    { S0005: (x509_cert.not_after - Time.now) > 7_776_000 }
   end
 
   chunk(:S0006) do
-    next unless PEStatusCheck.primary?
+    next unless ['primary'].include?(Facter.value('pe_status_check_role'))
+
     # Is puppet_metrics_collector running
     { S0006: PEStatusCheck.service_running_enabled('puppet_puppetserver-metrics.timer') }
   end
 
   chunk(:S0007) do
-    next unless PEStatusCheck.primary? || PEStatusCheck.replica? || PEStatusCheck.postgres?
+    next unless ['primary', 'replica', 'postgres'].include?(Facter.value('pe_status_check_role'))
+
     # check postgres data mount has at least 20% free
     pg_version = Facter.value(:pe_postgresql_info)['installed_server_version']
     data_dir = Facter.value(:pe_postgresql_info)['versions'][pg_version].fetch('data_dir', '/opt/puppetlabs/server/data/postgresql')
@@ -69,25 +67,29 @@ Facter.add(:pe_status_check, type: :aggregate) do
   end
 
   chunk(:S0008) do
-    next unless PEStatusCheck.primary? || PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler?
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
     # check codedir data mount has at least 20% free
     { S0008: PEStatusCheck.filesystem_free(Puppet.settings['codedir']) >= 20 }
   end
 
   chunk(:S0009) do
-    next unless PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler? || PEStatusCheck.primary?
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
     # Is the Pe-puppetsever Service Running and Enabled
     { S0009: PEStatusCheck.service_running_enabled('pe-puppetserver') }
   end
 
   chunk(:S0010) do
-    next unless PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.primary?
+    next unless ['primary', 'replica', 'pe_compiler'].include?(Facter.value('pe_status_check_role'))
+
     # Is the pe-puppetdb Service Running and Enabled
     { S0010: PEStatusCheck.service_running_enabled('pe-puppetdb') }
   end
 
   chunk(:S0011) do
-    next unless PEStatusCheck.replica? || PEStatusCheck.postgres? || PEStatusCheck.primary?
+    next unless ['primary', 'replica', 'postgres'].include?(Facter.value('pe_status_check_role'))
+
     # Is the pe-postgres Service Running and Enabled
     postgresversion = PEStatusCheck.pe_postgres_service_name
     { S0011: PEStatusCheck.service_running_enabled(postgresversion.to_s) }
@@ -96,6 +98,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
   chunk(:S0012) do
     summary_path = Puppet.settings['lastrunfile']
     next unless File.exist?(summary_path)
+
     # Did Puppet Produce a report in the last run interval
     lastrunfile = YAML.load_file(summary_path)
     time_lastrun = lastrunfile.dig('time', 'last_run')
@@ -110,6 +113,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
   chunk(:S0013) do
     summary_path = Puppet.settings['lastrunfile']
     next unless File.exist?(summary_path)
+
     # Did catalog apply successfully on last puppet run
     { S0013: File.open(summary_path).read.include?('catalog_application') }
   end
@@ -131,7 +135,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0016) do
     # Puppetserver
-    next unless PEStatusCheck.primary? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler? || PEStatusCheck.replica?
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
     time_now = Time.now - Puppet.settings['runinterval']
     log_path = File.dirname(Puppet.settings['logdir'].to_s) + '/puppetserver/'
     error_pid_log = Dir.glob(log_path + '*_err_pid*.log').find { |f| time_now.to_i < File.mtime(f).to_i }
@@ -146,7 +151,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0017) do
     # PuppetDB
-    next unless PEStatusCheck.primary? || PEStatusCheck.compiler?
+    next unless ['primary', 'pe_compiler'].include?(Facter.value('pe_status_check_role'))
+
     time_now = Time.now - Puppet.settings['runinterval']
     log_path = File.dirname(Puppet.settings['logdir'].to_s) + '/puppetdb/'
     error_pid_log = Dir.glob(log_path + '*_err_pid*.log').find { |f| time_now.to_i < File.mtime(f).to_i }
@@ -161,7 +167,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0018) do
     # Orchestrator
-    next unless PEStatusCheck.primary?
+    next unless ['primary'].include?(Facter.value('pe_status_check_role'))
+
     time_now = Time.now - Puppet.settings['runinterval']
     log_path = File.dirname(Puppet.settings['logdir'].to_s) + '/orchestration-services/'
     error_pid_log = Dir.glob(log_path + '*_err_pid*.log').find { |f| time_now.to_i < File.mtime(f).to_i }
@@ -175,7 +182,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
   end
 
   chunk(:S0019) do
-    next unless PEStatusCheck.primary? || PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler?
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
     response = PEStatusCheck.http_get('/status/v1/services/pe-jruby-metrics?level=debug', 8140)
     if response
       free_jrubies = response.dig('status', 'experimental', 'metrics', 'average-free-jrubies')
@@ -201,19 +209,19 @@ Facter.add(:pe_status_check, type: :aggregate) do
         if license_type.include? 'Perpetual'
           validity = true
         elsif license_type.include? 'Subscription'
-          require 'date'
+        require 'date'
           begin
             end_date = Date.parse(File.readlines(license_file).grep(%r{end:}).first)
-            today_date = Date.today
-            daysexp = (end_date - today_date).to_i
+        today_date = Date.today
+        daysexp = (end_date - today_date).to_i
             validity = (today_date <= end_date) && (daysexp >= 90) ? true : false
           rescue StandardError => e
             Facter.warn("Error in fact 'pe_status_check.S0022' when checking license end date: #{e.message}")
             Facter.debug(e.backtrace)
             # license file has missing or invalid end date
             validity = false
-          end
-        else
+      end
+    else
           # license file has invalid license_type
           validity = false
         end
@@ -229,7 +237,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
   end
 
   chunk(:S0024) do
-    next unless PEStatusCheck.primary? || PEStatusCheck.replica? || PEStatusCheck.compiler?
+    next unless ['primary', 'replica', 'pe_compiler'].include?(Facter.value('pe_status_check_role'))
 
     # Check discard directory. Newest file should not be less than a run interval old. Recent files indicate an issue that causes PuppetDB to reject incoming data.
     newestfile = Dir.glob('/opt/puppetlabs/server/data/puppetdb/stockpile/discard/*.*').max_by { |f| File.mtime(f) }
@@ -264,7 +272,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0031) do
     # check for Old pe_repo versions have been cleaned up
-    next unless PEStatusCheck.primary?
+    next unless ['primary'].include?(Facter.value('pe_status_check_role'))
+
     pe_version = Facter.value(:pe_server_version)
     packages_dir = '/opt/puppetlabs/server/data/packages/public'
     no_old_packages = true
@@ -288,7 +297,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
   end
 
   chunk(:S0033) do
-    next unless PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler? || PEStatusCheck.primary?
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
     hiera_config_path = Puppet.settings['hiera_config']
     next unless File.exist?(hiera_config_path)
     hiera_config_file = YAML.load_file(hiera_config_path)
@@ -296,8 +306,26 @@ Facter.add(:pe_status_check, type: :aggregate) do
     { S0033: hiera_config_file.dig('version') == 5 }
   end
 
+  chunk(:S0036) do
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
+    str = IO.read('/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf')
+    max_queued_requests = str.match(%r{max-queued-requests: (\d+)})
+    if max_queued_requests.nil?
+      { S0036: true }
+    else
+      { S0036: max_queued_requests[1].to_i < 150 }
+    end
+  end
+
+  chunk(:S0040) do
+    # Is puppet_metrics_collector::system configured
+    { S0040: PEStatusCheck.service_running_enabled('puppet_system_processes-metrics.timer') }
+  end
+
   chunk(:S0034) do
-    next unless PEStatusCheck.primary?
+    next unless ['primary'].include?(Facter.value('pe_status_check_role'))
+
     # PE has not been upgraded / updated in 1 year
     # It was decided not to include infra components as this was deemed unecessary as they should align with the primary.
 
@@ -342,7 +370,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0039) do
     # PuppetServer
-    next unless PEStatusCheck.primary? || PEStatusCheck.replica? || PEStatusCheck.compiler? || PEStatusCheck.legacy_compiler?
+    next unless ['primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
+
     logfile = File.dirname(Puppet.settings['logdir'].to_s) + '/puppetserver/puppetserver-access.log'
     apache_regex = %r{^(\S+) \S+ (\S+) (?<time>\[([^\]]+)\]) "([A-Z]+) ([^ "]+)? HTTP/[0-9.]+" (?<status>[0-9]{3})}
 

--- a/lib/facter/pe_status_check_role.rb
+++ b/lib/facter/pe_status_check_role.rb
@@ -1,0 +1,36 @@
+Facter.add(:pe_status_check_role) do
+  require 'puppet'
+  require_relative '../shared/pe_status_check'
+
+  setcode do
+    classfile = Puppet.settings[:classfile]
+    return nil unless File.file?(classfile)
+
+    node_profiles = []
+    # Turn the list of infra roles defined in the module constant into a regex we can use with grep()
+    profile_regex = %r{^puppet_enterprise::profile::(#{PEStatusCheck.infra_profiles.join('|')})$}
+
+    File.open(classfile).grep(profile_regex) do |profile|
+      # Strip the leading 'puppet_enterprise::profile::' from each match
+      short_profile = profile.split(':')[-1].chomp
+      # Add unique entries to the node_profiles array by doing a bitwise or between it and the current match
+      # e.g. `['foo', 'bar'] | ['bar', 'baz']` produces `['foo', 'bar', 'baz']`
+      node_profiles |= [short_profile]
+    end
+
+    if node_profiles.include?('certificate_authority')
+        then 'primary'
+    elsif node_profiles.include?('primary_master_replica')
+        then 'replica'
+      # Use array subtraction to determine if more than one role is present
+    elsif (['master', 'puppetdb'] - node_profiles).empty?
+        then 'pe_compiler'
+    elsif node_profiles.include?('master')
+        then 'legacy_compiler'
+    elsif node_profiles.include?('database')
+        then 'postgres'
+    else
+      'unknown'
+    end
+  end
+end

--- a/lib/facter/pe_status_check_role.rb
+++ b/lib/facter/pe_status_check_role.rb
@@ -1,7 +1,7 @@
 Facter.add(:pe_status_check_role) do
+  confine { Facter.value(:pe_build) }
   require 'puppet'
   require_relative '../shared/pe_status_check'
-
   setcode do
     classfile = Puppet.settings[:classfile]
     return nil unless File.file?(classfile)

--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -6,10 +6,10 @@ require 'openssl'
 # PEStatusCheck - Shared code for pe_status_check facts
 module PEStatusCheck
   class << self
-    attr_accessor :infra_profiles, :PUP_PATHS
+    attr_accessor :infra_profiles, :pup_paths
   end
 
-  self.PUP_PATHS ||= { server_bin: '/opt/puppetlabs/server/bin' }.freeze
+  self.pup_paths ||= { server_bin: '/opt/puppetlabs/server/bin' }.freeze
 
   # List of profiles classes applied to PE nodes we can use to determine a node's role
   self.infra_profiles = [
@@ -19,7 +19,6 @@ module PEStatusCheck
     'certificate_authority',
     'primary_master_replica',
   ]
-
 
   module_function
 
@@ -130,7 +129,7 @@ module PEStatusCheck
 
   # Get the maximum defined and current connections to Postgres
   def psql_return_result(sql, psql_options = '')
-    command = %(su pe-postgres --shell /bin/bash --command "cd /tmp && #{PUP_PATHS[:server_bin]}/psql #{psql_options} --command \\"#{sql}\\"")
+    command = %(su pe-postgres --shell /bin/bash --command "cd /tmp && #{pup_paths[:server_bin]}/psql #{psql_options} --command \\"#{sql}\\"")
     Facter::Core::Execution.execute(command)
   end
 
@@ -149,7 +148,6 @@ module PEStatusCheck
     psql_options = '-qtAX'
     psql_return_result(sql, psql_options)
   end
-
 
   # Get the free disk percentage from a path
   # @param name [String] The path on the file system


### PR DESCRIPTION
This commit introduces a new fact, pe_status_check_role, to determine
a node's role in a PE infrastructure.  We do this using the list of
classes in the classfile setting and checking for certain PE profile
classes.