### PR TITLE
(SUP-3101) Bug fix S0022

### DIFF
--- a/spec/acceptance/pe_status_check_spec.rb
+++ b/spec/acceptance/pe_status_check_spec.rb
@@ -200,9 +200,12 @@ describe 'pe_status_check class' do
       end
       it 'if S0022 conditions for false are met' do
         run_shell('mv /etc/puppetlabs/license.key /tmp/license.key')
+        run_shell('echo -e "#######################\n#  Begin License File #\n#######################\n \n# PUPPET ENTERPRISE LICENSE - test
+          \nuuid: test\n \nto: test\n \nnodes: 100\n \nlicense_type: Subscription\n \nsupport_type: PE Premium\n \nstart: 2022-01-01\n \nend: 2022-03-29
+          \n#####################\n#  End License File #\n#####################" > /etc/puppetlabs/license.key')
         result = run_shell('facter -p pe_status_check.S0022')
         expect(result.stdout).to match(%r{false})
-        run_shell('mv /tmp/license.key /etc/puppetlabs/license.key')
+        run_shell('mv -f /tmp/license.key /etc/puppetlabs/license.key')
       end
       it 'if S0024 conditions for false are met' do
         run_shell('touch -d "30 minutes ago"  /opt/puppetlabs/server/data/puppetdb/stockpile/discard/test.file')


### PR DESCRIPTION
### Prior to this commit
---
pe_status_check.S0022 would exist even when there wasn't a license file present on the primary server.
Facter would crash if end or start dates didn't exist or could not be converted to valid date objects.
The default condition was `true` for this fact.
The spec test only checked for absence of license.key to attempt to set up a failure condition.

### This commit
---
Now fact pe_status_check.S0022 will only exist if there is a license file located on the primary server. Previously the fact would resolve to a default value of `true`.

Now pe_status_check.S0022 will resolve to `true` if the license file is valid and does not expire within the next 90 days or if it's a Perpetual license.
Now pe_status_check.S0022 will resolve to `false` if the license will expire within 90 days, if the license file is missing or contains an invalid end date, or if the license file does not contain a valid Perpetual or Subscription `license_type`.

This commit also modifies the spec test for S0022. Previously the spec test expected a failure if the license file doesn't exist on the machine. Now the spec test adds a new temporary license file with an end date that has already passed for the failure condition.

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
