### PR TITLE
Bump pe_status_check count to 30

### DIFF
--- a/spec/acceptance/pe_status_check_spec.rb
+++ b/spec/acceptance/pe_status_check_spec.rb
@@ -15,7 +15,7 @@ describe 'pe_status_check class' do
     # Test Confirms all facts are false which is another indicator the class is performing correctly
     describe 'check no pe_status_check fact is false' do
       it 'if idempotent all facts should be true' do
-        expect(host_inventory['facter']['pe_status_check'].size).to eq(29)
+        expect(host_inventory['facter']['pe_status_check'].size).to eq(30)
         expect(host_inventory['facter']['pe_status_check'].filter { |_k, v| !v }).to be_empty
       end
     end


### PR DESCRIPTION
This commit bumps the expected number of chunks in the pe_status_check
fact to the correct number, 30.