### PR TITLE
(SUP-3180) Rescue a loaderror when checking filesystem

### DIFF
--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -190,5 +190,9 @@ module PEStatusCheck
 
     stat = Sys::Filesystem.stat(path)
     (stat.blocks_available.to_f / stat.blocks.to_f * 100).to_i
+  rescue LoadError => e
+    Facter.warn("Error in fact 'pe_status_check': #{e.message}")
+    Facter.debug(e.backtrace)
+    0
   end
 end


### PR DESCRIPTION
Prior to this commit, if 'sys/filesystem' failed to load in the fact
resolution, 'puppet facts show' would fail with an empty output. This
would cause problems with `puppet infra run` commands as it uses a
different ruby stack than the puppet-agent. This commit catches the
loaderror and causes any checks that use it to be false.

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
