### PR TITLE
(SUP-3005) Update plan output format

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,4 @@
 --relative
+--no-unquoted_string_in_case-check
+--no-strict_indent-check
+--no-manifest_whitespace_opening_brace_befor-check

--- a/.sync.yml
+++ b/.sync.yml
@@ -34,10 +34,14 @@ spec/spec_helper.rb:
   coverage_report: true
 Rakefile:
   changelog_user: "puppetlabs"
+  extra_disabled_lint_checks:
+    - unquoted_string_in_case
+    - strict_indent
+    - manifest_whitespace_opening_brace_befor
 spec/default_facts.yml:
   extra_facts:
     pe_build: '2021.4.0'
-    
+
 Gemfile:
   optional:
     ":development":

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class { 'pe_status_check':
 
 ### Ad-hoc Report (Plan)
 
-The plan, `pe_status_check::infra_summary`, summarizes the status of each of the checks on target nodes that have the pe_status_check fact, sample output can be seen below:
+The plan, `pe_status_check::infra_summary`, summarizes the status of each of the checks on target nodes that have the `pe_status_check` fact, sample output can be seen below:
 
 ```json
 {
@@ -112,7 +112,7 @@ The plan, `pe_status_check::infra_summary`, summarizes the status of each of the
 
 #### Setup Requirements
 
-`pe_status_check::infra_summary` utilizes [hiera](https://puppet.com/docs/puppet/latest/hiera_intro.html) to lookup test definitions, this requires placing a static hierarchy in your **environment level** [hiera.yaml](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html). Refer to the [bolt with hiera documentation](https://puppet.com/docs/bolt/latest/hiera.html) for more information.
+`pe_status_check::infra_summary` utilizes [hiera](https://puppet.com/docs/puppet/latest/hiera_intro.html) to lookup test definitions, this requires placing a static hierarchy in your **environment level** [hiera.yaml](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html).
 
 ```yaml
 plan_hierarchy:
@@ -121,13 +121,30 @@ plan_hierarchy:
     data_hash: yaml_data
 ```
 
-Example call from the command line:
+See the following [documentation](https://puppet.com/docs/bolt/latest/hiera.html#outside-apply-blocks) for further explanation.
+
+#### Running the plan
+
+The `pe_status_check::infra_summary` plan can be run from the [PE console](https://puppet.com/docs/pe/latest/running_plans_from_the_console_.html) or from [the command line](https://puppet.com/docs/pe/latest/running_plans_from_the_command_line.html). Below are some examples of running the plan from the command line. More information on the parameters in the plan can be seen in the [REFERENCE.md](REFERENCE.md).
+
+Example call from the command line to run against all infrastructure nodes:
 
 ```shell
- puppet plan run pe_status_check::infra_summary targets=pe-compiler-c960c9-0.region-a.domain.com,pe-psql-c960c9-0.region-a.domain.com
+puppet plan run pe_status_check::infra_summary
 ```
 
-See the following [documentation](https://puppet.com/docs/bolt/latest/hiera.html#outside-apply-blocks) for further explanation.
+Example call from the command line to run against a set of infrastructure nodes:
+
+```shell
+puppet plan run pe_status_check::infra_summary targets=pe-server-70aefa-0.region-a.domain.com,pe-psql-70aefa-0.region-a.domain.com
+```
+
+Example call from the command line to exclude indicators :
+
+```shell
+puppet plan run pe_status_check::infra_summary -p '{"indicator_exclusions": ["S0001","S0021"]}'
+```
+
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     - [Setup requirements](#setup-requirements)
     - [Beginning with pe_status_check](#beginning-with-pe_status_check)
   - [Usage](#usage)
-  - [Reporting options](#reporting-options)
+  - [Reporting Options](#reporting-options)
     - [Class declaration (optional)](#class-declaration-optional)
     - [Ad-hoc Report (Plan)](#ad-hoc-report-plan)
   - [Reference](#reference)
@@ -41,9 +41,7 @@ The facts in this module can be directly consumed by monitoring tools such as Sp
 
 Alternatively, assigning the `class pe_status_check` to the infrastructure notifies on each Puppet run if any indicator is reporting as `false`.
 
-
 ## Reporting Options
-
 
 ### Class declaration (optional)
 
@@ -67,35 +65,66 @@ class { 'pe_status_check':
 
 ### Ad-hoc Report (Plan)
 
-The plan pe_status_check::infra_summary, summarises the status of each of the checks on target nodes that have the pe_status_check fact, sample output can be seen below:
+The plan, `pe_status_check::infra_summary`, summarizes the status of each of the checks on target nodes that have the pe_status_check fact, sample output can be seen below:
 
+```json
+{
+    "nodes": {
+        "details": {
+            "pe-psql-70aefa-0.region-a.domain.com": {
+                "failed_tests_count": 0,
+                "passing_tests_count": 13,
+                "failed_tests_details": []
+            },
+            "pe-server-70aefa-0.region-a.domain.com": {
+                "failed_tests_count": 1,
+                "passing_tests_count": 30,
+                "failed_tests_details": [
+                    "S0022 Determines if there is a valid Puppet Enterprise license in place at /etc/puppetlabs/license.key on your primary which is not going to expire in the next 90 days"
+                ]
+            },
+            "pe-compiler-70aefa-0.region-a.domain.com": {
+                "failed_tests_count": 0,
+                "passing_tests_count": 23,
+                "failed_tests_details": []
+            },
+            "pe-compiler-70aefa-1.region-b.domain.com": {
+                "failed_tests_count": 0,
+                "passing_tests_count": 23,
+                "failed_tests_details": []
+            }
+        },
+        "failing": [
+            "pe-server-70aefa-0.region-a.domain.com"
+        ],
+        "passing": [
+            "pe-compiler-70aefa-1.region-b.domain.com",
+            "pe-compiler-70aefa-0.region-a.domain.com",
+            "pe-psql-70aefa-0.region-a.domain.com"
+        ]
+    },
+    "errors": {},
+    "status": "failing",
+    "failing_node_count": 1,
+    "passing_node_count": 3
+}
+```
 
-```
-    {
-        "pe-server-c960c9-0.us-west1-a.c.customer-support-scratchpad.internal": {
-            "Failed Test Count": 2,
-            "Failed Test Details": [
-                "S0022 Determines if there is a valid Puppet Enterprise license in place at /etc/puppetlabs/license.key on your primary which is not going to expire in the next 90 days",
-                "S0001 Determines if Puppet agent Service is running"
-            ],
-            "Passing Tests Count": 29
-        }
-    }
-```
 #### Setup Requirements
 
-pe_status_check::infra_summary utlizes hiera to lookup test definitions, this requires placing a static hierarchy in your environment level hiera.yaml
+`pe_status_check::infra_summary` utilizes [hiera](https://puppet.com/docs/puppet/latest/hiera_intro.html) to lookup test definitions, this requires placing a static hierarchy in your **environment level** [hiera.yaml](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html). Refer to the [bolt with hiera documentation](https://puppet.com/docs/bolt/latest/hiera.html) for more information.
 
-```
+```yaml
 plan_hierarchy:
   - name: "Static data"
-    data_hash: yaml_data
     path: "static.yaml"
+    data_hash: yaml_data
 ```
 
-Example call:
-```
- puppet plan run pe_status_check::infra_summary targets=pe-compiler-c960c9-0.us-west1-a.c.customer-support-scratchpad.internal,pe-psql-c960c9-0.us-west1-a.c.customer-support-scratchpad.internal
+Example call from the command line:
+
+```shell
+ puppet plan run pe_status_check::infra_summary targets=pe-compiler-c960c9-0.region-a.domain.com,pe-psql-c960c9-0.region-a.domain.com
 ```
 
 See the following [documentation](https://puppet.com/docs/bolt/latest/hiera.html#outside-apply-blocks) for further explanation.
@@ -104,9 +133,7 @@ See the following [documentation](https://puppet.com/docs/bolt/latest/hiera.html
 
 Refer to this section for next steps when any indicator reports a `false`.
 
-
 ## Fact: pe_status_check
-
 
 | Indicator ID | Description                                                                        | Self-service steps                                                                                                                                                                                                                                                                                                                                                                                                                                                          | What to include in a Support ticket                                                                                                                                                                                                   |
 |--------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -142,7 +169,6 @@ Refer to this section for next steps when any indicator reports a `false`.
 | S0040        | Determines if PE is collecting system metrics.                    | If system metrics are not collected by default, the sysstat package is not installed on the impacted PE infrastructure component. Install the package and set the parameter `puppet_enterprise::enable_system_metrics_collection` to true. [See the documentation.](https://puppet.com/docs/pe/latest/getting_support_for_pe.html#puppet_metrics_collector)                                                                   | After system metrics are configured, you do not see any files in `/var/log/sa` or if the `/var/log/sa` directory does not exist, open a Support ticket.                                                 |
 | S0041        | Determines if the pxp broker on a compiler  has an established connection to another pxp broker  | To resolve a connection issue from a compiler to a pcp broker examine the following log `/var/log/puppetlabs/puppetserver/pcp-broker.log` for an explanation, Compilers should be attempting to make a connection to port 8143 on the primary server, ssl can not be terminated on a network appliance and must passthrough directly to the primary server. Ensure the connnection attempt is not to another compiler in the pool            | If unable to make a connection to a broker, raise a ticket with the support team quoting S0041 and attaching the file `/var/log/puppetlabs/puppetserver/pcp-broker.log` along with the conclusions of your investigation so far            |
 | S0042        |Determines if the pxp-agent has an established connection to a pxp broker                   | Ensure the pxp-agent service is running. Check S0002 can make that determination. if running check `/var/log/puppetlabs/pxp-agent/pxp-agent.log` for connection issues, first ensuring the agent is connecting to the proper endpoint, for example, a compiler and not the primary. This fact can also be used as a target filter for running tasks, ensuring time is not wasted sending instructions to agents not connected to a broker                   | If unable to make a connection to a broker, raise a ticket with the support team quoting S0042 and attaching the file `/var/log/puppetlabs/pxp-agent/pxp-agent.log` along with the conclusions of your investigation so far             |
-
 
 ## Fact: agent_status_check
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,12 @@
 
 * [`pe_status_check`](#pe_status_check): This class should be enabled if you wish Puppet to notify when pe_status_check indicators are not at optimal values
 
+### Plans
+
+* [`pe_status_check::infra_summary`](#pe_status_checkinfra_summary): Summary report if the state of pe_status check on each node
+Uses the facts task to get the current status from each node
+and produces a summary report in JSON
+
 ## Classes
 
 ### <a name="pe_status_check"></a>`pe_status_check`
@@ -28,6 +34,38 @@ include pe_status_check
 The following parameters are available in the `pe_status_check` class:
 
 * [`indicator_exclusions`](#indicator_exclusions)
+
+##### <a name="indicator_exclusions"></a>`indicator_exclusions`
+
+Data type: `Array[String[1]]`
+
+List of disabled indicators, place any indicator ids you do not wish to report on in this list
+
+Default value: `[]`
+
+## Plans
+
+### <a name="pe_status_checkinfra_summary"></a>`pe_status_check::infra_summary`
+
+Summary report if the state of pe_status check on each node
+Uses the facts task to get the current status from each node
+and produces a summary report in JSON
+
+#### Parameters
+
+The following parameters are available in the `pe_status_check::infra_summary` plan:
+
+* [`targets`](#targets)
+* [`indicator_exclusions`](#indicator_exclusions)
+
+##### <a name="targets"></a>`targets`
+
+Data type: `Optional[TargetSpec]`
+
+A comma seprated list of FQDN's of Puppet infrastructure agent nodes
+Defaults to using a PuppetDB query to identify nodes
+
+Default value: ``undef``
 
 ##### <a name="indicator_exclusions"></a>`indicator_exclusions`
 

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,9 @@ def changelog_future_release
 end
 
 PuppetLint.configuration.send('disable_relative')
+PuppetLint.configuration.send('disable_unquoted_string_in_case')
+PuppetLint.configuration.send('disable_strict_indent')
+PuppetLint.configuration.send('disable_manifest_whitespace_opening_brace_befor')
 
 
 if Bundler.rubygems.find_name('github_changelog_generator').any?

--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,7 @@
       "version_requirement": ">= 6.16.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.3.0",
+  "pdk-version": "2.4.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-gf3911d3"
+  "template-ref": "heads/main-0-g806810b"
 }

--- a/plans/infra_summary.pp
+++ b/plans/infra_summary.pp
@@ -1,22 +1,91 @@
-# @summary Summary report if the state of pe_status check on each node 
+# @summary Summary report if the state of pe_status check on each node
 #   Uses the facts task to get the current status from each node
 #   and produces a summary report in JSON
 # @param targets
 #   A comma seprated list of FQDN's of Puppet infrastructure agent nodes
-# 
-
-plan pe_status_check::infra_summary(TargetSpec $targets) {
-  $results = run_task('facts', $targets, '_catch_errors' => true)
-
-  # Filter $results to a subset where at least one of the checks has passed
-  $failed_checks = $results.ok_set.filter |$result| {
-    $result['pe_status_check'].any |$k, $v| { $v }
+# @param indicator_exclusions
+#  List of disabled indicators, place any indicator ids you do not wish to report on in this list
+plan pe_status_check::infra_summary(
+  TargetSpec $targets,
+  Array[String[1]] $indicator_exclusions = [],
+) {
+  # Validate that hiera lookups are functional
+  $hiera_result_or_error = catch_errors() || {
+    lookup('pe_status_check::S0001', String)
+  }
+  if $hiera_result_or_error =~ Error {
+    log::warn('Hiera lookups are not functional with plans. See the "Setup Requirements" section of the README')
   }
 
-  return $failed_checks.map |$node| {
-    # Create a hash where the key is the certname and an array of hashes gives counts for passes and fails and the IDS for failed tests
-    {
-      $node.target.name => { 'Passing Tests Count' => count($node['pe_status_check'].filter |$k, $v| { $v }.keys), 'Failed Test Count' => count ($node['pe_status_check'].filter |$k, $v| { !$v }.keys) ,'Failed Test Details'  => $node['pe_status_check'].filter |$k, $v| { !$v }.keys.map |$items| { lookup("pe_status_check::${items}", String,'hash') } }
+  # Get the facts from the Targets to use for processing
+  $results = without_default_logging() || {
+    run_task('facts', $targets, '_catch_errors' => true)
+  }
+
+  # Report on failures while collecting facts
+  $fact_task_errors = $results.error_set.ok ? {
+    true    => {},
+    default => $results.error_set.reduce({}) |$memo, $e| {
+      $memo + {
+        $e.target.name => $e.error.message
+      }
     }
   }
+
+  # Parse the results to identify nodes with the fact
+  $pe_status_check_results = $results.ok_set.filter |$r| { $r['pe_status_check'] =~ NotUndef and ! $r['pe_status_check'].empty }
+  $missing = $results.ok_set.filter |$r| { $r['pe_status_check'] =~ Undef or $r['pe_status_check'].empty }
+  $missing_errors = $missing.reduce({}) |$memo, $r| {
+    $memo + {
+      $r.target.name => $r['pe_build'] =~ Undef ? {
+        true    => 'This plan does not check the status of agent nodes',
+        default => 'Missing the \'pe_status_check\' fact'
+      }
+    }
+  }
+
+  # Generate a summary of nodes with passing and failing
+  $output_format = {
+    'details' => {},
+    'passing' => [],
+    'failing' => [],
+  }
+  $node_summary = $pe_status_check_results.reduce($output_format) |$memo, $res| {
+    $failing = $res['pe_status_check'].filter |$k, $v| { ! $v and ! ($k in $indicator_exclusions) }
+    $passing = $res['pe_status_check'].filter |$k, $v| { $v and ! ($k in $indicator_exclusions) }
+    $state = $failing.empty ? {
+      true => 'passing',
+      default => 'failing'
+    }
+    $details = {
+      $res.target.name => {
+        'passing_tests_count' => $passing.length,
+        'failed_tests_count'   => $failing.length,
+        'failed_tests_details' => $failing.keys.map |$items| {
+          unless $hiera_result_or_error =~ Error {
+            lookup("pe_status_check::${items}", String)
+          }
+        },
+      },
+    }
+    $memo + {
+      $state => $memo[$state] + [$res.target.name],
+      'details' => $memo['details'] + $details,
+    }
+  }
+
+  $status = ( $node_summary['failing'].empty and $missing.empty and $fact_task_errors.empty ) ? {
+    true    => 'passing',
+    default => 'failing'
+  }
+
+  # Build the output hash
+  $return = {
+    'nodes'  => $node_summary,
+    'errors' => $missing_errors + $fact_task_errors,
+    'status' => $status,
+    'passing_node_count' => $node_summary['passing'].length,
+    'failing_node_count' => $node_summary['failing'].length + $missing.length,
+  }
+  return $return
 }


### PR DESCRIPTION
This commit changes the output of the plan format to have a summary and
details. It aligns the parameters with the init.pp class to ensure that
the plan can handle excluding checks.

Output examples:
```
{
    "nodes": {
        "details": {
            "puppet.example.com": {
                "Failed Test Count": 0,
                "Failed Test Details": [],
                "Passing Tests Count": 28
            }
        },
        "failing": [],
        "passing": [
            "puppet.example.com"
        ]
    },
    "errors": {
        "agent.example.com": "Missing the 'pe_status_check' fact"
    },
    "passed": false,
    "failing_node_count": 1,
    "passing_node_count": 1
}
```

```
{
  "nodes": {
      "details": {
          "puppet.example.com": {
              "Failed Test Count": 0,
              "Failed Test Details": [],
              "Passing Tests Count": 28
          }
      },
      "failing": [],
      "passing": [
          "puppet.example.com"
      ]
  },
  "errors": {},
  "passed": true,
  "failing_node_count": 0,
  "passing_node_count": 1
}
```