### PR TITLE
(SUP-3426) Use shorter timeout for facter execute

### DIFF
--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -20,14 +20,16 @@ Facter.add(:agent_status_check, type: :aggregate) do
     valid_families = ['windows', 'Debian', 'RedHat', 'Suse']
     next unless valid_families.include?(Facter.value(:os)['family'])
     result = if Facter.value(:os)['family'] == 'windows'
-               Facter::Core::Execution.execute('netstat -n | findstr /c:"8142"  | findstr /c:"TCP"  | findstr /c:"ESTABLISHED"')
+               Facter::Core::Execution.execute('netstat -n | findstr /c:"8142"  | findstr /c:"TCP"  | findstr /c:"ESTABLISHED"',
+                                               { timeout: PEStatusCheck.facter_timeout })
              else
-               Facter::Core::Execution.execute('ss -tunp | grep ESTAB | grep 8142 | grep pxp-agent')
+               Facter::Core::Execution.execute('ss -tunp | grep ESTAB | grep 8142 | grep pxp-agent',
+                                               { timeout: PEStatusCheck.facter_timeout })
              end
     { AS002: !result.empty? }
   rescue Facter::Core::Execution::ExecutionFailure => e
-    Facter.warn('agent_status_check.AS002 failed to get socket status')
-    Facter.debug(e)
+    Facter.warn("agent_status_check.AS002 failed to get socket status: #{e.message}")
+    Facter.debug(e.backtrace)
     { AS002: false }
   end
 end

--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -6,10 +6,11 @@ require 'openssl'
 # PEStatusCheck - Shared code for pe_status_check facts
 module PEStatusCheck
   class << self
-    attr_accessor :infra_profiles, :pup_paths
+    attr_accessor :infra_profiles, :pup_paths, :facter_timeout
   end
 
   self.pup_paths ||= { server_bin: '/opt/puppetlabs/server/bin' }.freeze
+  self.facter_timeout ||= 2
 
   # List of profiles classes applied to PE nodes we can use to determine a node's role
   self.infra_profiles = [
@@ -130,7 +131,7 @@ module PEStatusCheck
   # Get the maximum defined and current connections to Postgres
   def psql_return_result(sql, psql_options = '')
     command = %(su pe-postgres --shell /bin/bash --command "cd /tmp && #{pup_paths[:server_bin]}/psql #{psql_options} --command \\"#{sql}\\"")
-    Facter::Core::Execution.execute(command)
+    Facter::Core::Execution.execute(command, { timeout: facter_timeout })
   end
 
   def max_connections


### PR DESCRIPTION
This commit adds a timeout of 2 seconds for Facter's .execute method.
It also standardizes some of the error handling.