### PR TITLE
(SUP-3423) Update metadata to reflect supported agent OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,13 +40,38 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+	"20.04"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "10",
+        "2012",
+        "2012 R2",
+        "2016",
+        "2019",
+        "2022"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12"
+        "12",
+	"15"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],


### PR DESCRIPTION
Prior to this commit it wasnt indicated that windows was supported for agent_status_check

Also added newly added supported OS versions