### PR TITLE
(SUP-3450) make agent_status_check collection optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
     - [Setup requirements](#setup-requirements)
     - [Beginning with pe_status_check](#beginning-with-pe_status_check)
   - [Usage](#usage)
+    - [Enabling agent_status_check](#enabling-agent_status_check)
+    - [Disabling agent_status_check](#disabling-agent_status_check)
   - [Reporting Options](#reporting-options)
-    - [Class declaration (optional)](#class-declaration-optional)
+    - [Class declaration pe_status_check (optional)](#class-declaration-pe_status_check-optional)
     - [Ad-hoc Report (Plans)](#ad-hoc-report-plans)
     - [Using a Puppet Query to report status.](#using-a-puppet-query-to-report-status)
       - [Setup Requirements](#setup-requirements-1)
@@ -38,6 +40,7 @@ Install the module, plug-in sync will be used to deliver the required facts for 
 ### Beginning with pe_status_check
 
 This module primarily provides indicators using facts, so installing the module and allowing plug-in sync to occur lets the module start functioning.
+Collection of the `agent_status_check` fact is disabled by default so as not to affect all puppet agents indiscriminately
 
 ## Usage
 
@@ -45,9 +48,19 @@ The facts in this module can be directly consumed by monitoring tools such as Sp
 
 Alternatively, assigning the `class pe_status_check` to the infrastructure notifies on each Puppet run if any indicator is reporting as `false`, this can be viewed in the Puppet report for each node.
 
+### Enabling agent_status_check
+
+By default your normal agent population will not collect the `agent_status_check` fact, this can be enabled for all agents or a subset of agents, by classifying pe_status_check::agent_status_enable to your nodes.
+
+### Disabling agent_status_check
+
+Following the addition of the class `pe_status_check::agent_status_enable` to an agent node, disable the collection of agent_status_check fact, set the following parameter:
+
+`pe_status_check::agent_status_enable::agent_status_enabled = false`
+
 ## Reporting Options
 
-### Class declaration (optional)
+### Class declaration pe_status_check (optional)
 
 To activate the notification functions of this module, classify your Puppet Infrastructure with the `pe_status_check` class using [your preferred classification method](https://puppet.com/docs/pe/latest/grouping_and_classifying_nodes.html#enable_console_configuration_data). Below is an example using `site.pp`.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,7 @@
 ### Classes
 
 * [`pe_status_check`](#pe_status_check): This class should be enabled if you wish Puppet to notify when pe_status_check indicators are not at optimal values
+* [`pe_status_check::agent_status_enable`](#pe_status_checkagent_status_enable): Enables the execution of agent_status_check fact
 
 ### Plans
 
@@ -45,6 +46,33 @@ Data type: `Array[String[1]]`
 List of disabled indicators, place any indicator ids you do not wish to report on in this list
 
 Default value: `[]`
+
+### <a name="pe_status_checkagent_status_enable"></a>`pe_status_check::agent_status_enable`
+
+Adding this class will enable the execution of the agent_status_check fact,
+This allows the fact to be targeted to a specific agent or group of agents
+
+#### Examples
+
+##### 
+
+```puppet
+include pe_status_check::agent_status_enable
+```
+
+#### Parameters
+
+The following parameters are available in the `pe_status_check::agent_status_enable` class:
+
+* [`agent_status_enabled`](#agent_status_enabled)
+
+##### <a name="agent_status_enabled"></a>`agent_status_enabled`
+
+Data type: `Boolean`
+
+Flag to enable or disable agent_status_check fact
+
+Default value: ``true``
 
 ## Plans
 

--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -1,8 +1,10 @@
 # Agent Status Check fact aims to have all chunks reporting as true, indicating ideal state, any individual chunk reporting false should be alerted on and checked against documentation for next steps
 # Use shared logic from PEStatusCheck
+# Disabled by default requires bundled class too create /opt/puppetlabs/puppet/cache/status_check_enable
 
 Facter.add(:agent_status_check, type: :aggregate) do
   confine { !Facter.value(:pe_build) }
+  next unless File.exist?('/opt/puppetlabs/puppet/cache/status_check_enable')
   require 'puppet'
 
   chunk(:AS001) do

--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -4,7 +4,7 @@
 
 Facter.add(:agent_status_check, type: :aggregate) do
   confine { !Facter.value(:pe_build) }
-  next unless File.exist?('/opt/puppetlabs/puppet/cache/status_check_enable')
+  next unless File.exist?('/opt/puppetlabs/puppet/cache/state/status_check_enable')
   require 'puppet'
 
   chunk(:AS001) do

--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -4,7 +4,7 @@
 
 Facter.add(:agent_status_check, type: :aggregate) do
   confine { !Facter.value(:pe_build) }
-  next unless File.exist?('/opt/puppetlabs/puppet/cache/state/status_check_enable')
+  confine { PEStatusCheck.enabled? }
   require 'puppet'
 
   chunk(:AS001) do

--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -151,7 +151,7 @@ module PEStatusCheck
   end
 
   # Get the free disk percentage from a path
-  # @param name [String] The path on the file system
+  # @param path [String] The path on the file system
   # @return [Integer] The percentage of free disk space on the mount
   def filesystem_free(path)
     require 'sys/filesystem'

--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -163,4 +163,13 @@ module PEStatusCheck
     Facter.debug(e.backtrace)
     0
   end
+
+  def enabled?
+    enabled_file = '/opt/puppetlabs/puppet/cache/state/status_check_enable'
+    if Facter.value('os')['name'] == 'windows'
+      enabled_file = File.join(Facter.value('common_appdata'),
+                               'PuppetLabs/puppet/cache/state/status_check_enable')
+    end
+    File.exist?(enabled_file)
+  end
 end

--- a/manifests/agent_status_enable.pp
+++ b/manifests/agent_status_enable.pp
@@ -8,22 +8,18 @@
 # @param [Boolean] agent_status_enabled
 #  Flag to enable or disable agent_status_check fact
 class pe_status_check::agent_status_enable (
-  Boolean       $agent_status_enabled               = true,
+Boolean $agent_status_enabled = true,
 ){
   $agent_status_enabled_file = $facts['os']['family'] ? {
     'windows' => "${facts['common_appdata']}/PuppetLabs/puppet/cache/state/status_check_enable",
     default   => '/opt/puppetlabs/puppet/cache/state/status_check_enable',
   }
-if $agent_status_enabled {
-      file {
-        $agent_status_enabled_file:
-          ensure => file,
-          mode   => '0664',
-      }
-    } else {
-      file {
-        $agent_status_enabled_file:
-          ensure => absent,
-      }
-    }
-  }
+$agent_status_enabled_file_ensure = $agent_status_enabled ? {
+  true     => 'file',
+  default => 'absent',
+}
+file { $agent_status_enabled_file:
+  ensure => $agent_status_enabled_file_ensure,
+  mode   => '0664',
+}
+}

--- a/manifests/agent_status_enable.pp
+++ b/manifests/agent_status_enable.pp
@@ -1,0 +1,29 @@
+# @summary Enables the execution of agent_status_check fact
+#
+# Adding this class will enable the execution of the agent_status_check fact, 
+# This allows the fact to be targeted to a specific agent or group of agents
+#
+# @example
+#   include pe_status_check::agent_status_enable
+# @param [Boolean] agent_status_enabled
+#  Flag to enable or disable agent_status_check fact
+class pe_status_check::agent_status_enable (
+  Boolean       $agent_status_enabled               = true,
+){
+  $agent_status_enabled_file = $facts['os']['family'] ? {
+    'windows' => "${facts['common_appdata']}/PuppetLabs/puppet/cache/state/status_check_enable",
+    default   => '/opt/puppetlabs/puppet/cache/state/status_check_enable',
+  }
+if $agent_status_enabled {
+      file {
+        $agent_status_enabled_file:
+          ensure => file,
+          mode   => '0664',
+      }
+    } else {
+      file {
+        $agent_status_enabled_file:
+          ensure => absent,
+      }
+    }
+  }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 #
 # @example
 #   include pe_status_check
-# @param [Array[String]] indicator_exclusions
+# @param [[Array][String]] indicator_exclusions
 #  List of disabled indicators, place any indicator ids you do not wish to report on in this list
 class pe_status_check (
   Array[String[1]] $indicator_exclusions = [],

--- a/spec/classes/agent_status_enable_spec.rb
+++ b/spec/classes/agent_status_enable_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'pe_status_check::agent_status_enable' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -7,4 +7,5 @@ ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
 pe_build: 2021.4.0
+common_appdata: 'C:/ProgramData'
 


### PR DESCRIPTION
Prior to this commit, the agent_status_check fact would sync to all nodes immediately following module installation.

Customers prefer to target and the fact specifically so a class has been added to enable this


