### PR TITLE
(SUP-3442) Update ss commands so timeout kills the process

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -417,8 +417,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
     next unless ['pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
 
     # Is pcp broker connected to another broker
-    result = Facter::Core::Execution.execute('ss -tunp | grep ESTAB | grep 8143 | grep java', { timeout: PEStatusCheck.facter_timeout }).strip
-    { S0041: !result.empty? }
+    result = Facter::Core::Execution.execute("ss -onp state established '( dport = :8143 )' ", { timeout: PEStatusCheck.facter_timeout })
+    { S0041: result.include?('java') }
   rescue Facter::Core::Execution::ExecutionFailure => e
     Facter.warn('pe_status_check.S0041 failed to get socket status from SS')
     Facter.debug(e)
@@ -428,8 +428,8 @@ Facter.add(:pe_status_check, type: :aggregate) do
   chunk(:S0042) do
     # Has the PXP agent establish a connection with a remote Broker
     #
-    result = Facter::Core::Execution.execute('ss -tunp | grep ESTAB | grep 8142 | grep pxp-agent', { timeout: PEStatusCheck.facter_timeout })
-    { S0042: !result.empty? }
+    result = Facter::Core::Execution.execute("ss -onp state established '( dport = :8142 )' ", { timeout: PEStatusCheck.facter_timeout })
+    { S0042: result.include?('pxp-agent') }
   rescue Facter::Core::Execution::ExecutionFailure => e
     Facter.warn("pe_status_check.S0042 failed to get socket status from SS: #{e.message}")
     Facter.debug(e.backtrace)


### PR DESCRIPTION
Updated the ss commands in the pe_status check and the agent status check to not pipe commands as it resulted in stuck processes not getting killed.
