### PR TITLE
(SUP-3452) Handle hostcert path missing

### DIFF
--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -10,6 +10,7 @@ Facter.add(:agent_status_check, type: :aggregate) do
   chunk(:AS001) do
     # Is the hostcert expiring within 90 days
     #
+    next unless File.exist?(Puppet.settings['hostcert'])
     raw_hostcert = File.read(Puppet.settings['hostcert'])
     certificate = OpenSSL::X509::Certificate.new raw_hostcert
     result = certificate.not_after - Time.now

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -137,6 +137,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0015) do
     # Is the hostcert expiring within 90 days
+    next unless File.exist?(Puppet.settings['hostcert'])
     raw_hostcert = File.read(Puppet.settings['hostcert'])
     certificate = OpenSSL::X509::Certificate.new raw_hostcert
     result = certificate.not_after - Time.now


### PR DESCRIPTION
Prior to this commit if hostcert resolved to a path that wasn't present, the entire agent_status_check fact would fail.
This could happen if certname was set in the agent section.

This handles the path presented by hostcert not being presenting by gracefully skipping that one chunk