### PR TITLE
Change log level in http_get to debug

### DIFF
--- a/lib/shared/pe_status_check.rb
+++ b/lib/shared/pe_status_check.rb
@@ -127,7 +127,7 @@ module PEStatusCheck
       false
     end
   rescue StandardError => e
-    Facter.warn("Error in fact 'pe_status_check' when querying #{path}: #{e.message}")
+    Facter.debug("Error in fact 'pe_status_check' when querying #{path}: #{e.message}")
     Facter.debug(e.backtrace)
     false
   end


### PR DESCRIPTION
Prior to this commit, this method would emit warnings during
installation or other times where Puppet server may not be available.
This commit lowers it to debug level to help avoid confusion during
upgrades.