### PR TITLE
(SUP-3724) error handling for access log parsing

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -464,6 +464,9 @@ Facter.add(:pe_status_check, type: :aggregate) do
       current = since_lastrun.to_i <= Puppet.settings['runinterval']
 
       match[:status] == '503' and current
+    rescue StandardError => e
+      Facter.warn("Error in fact 'pe_status_check.S0039' when querying puppetserver access logs: #{e.message}")
+      Facter.debug(e.backtrace)
     end
 
     { S0039: !has_503 }


### PR DESCRIPTION
Prior to this commit, if the puppetserver access logs where incorrectly formatted, facter resolution of the pe_status_check fact would end, and an error would be printed.

Following this update, the fact will resolve correctly and emit a warning about the formatting of the file.

Is of particular importance until https://tickets.puppetlabs.com/browse/PE-34726 is resolved, as locales other then en_gb and en_us cause issues with the access log formats