### PR TITLE
(SUP-3714) check console cert for expiration

### DIFF
--- a/data/static.yaml
+++ b/data/static.yaml
@@ -42,6 +42,7 @@ pe_status_check::S0039: "S0039 Determines if Puppetserver has a non zero queue-l
 pe_status_check::S0040: "S0040 Determines if the deployment is collecting system metrics"
 pe_status_check::S0041: "S0041 Determines if the pxp broker  has an established connection to another pxp broker"
 pe_status_check::S0042: "S0042 Determines if the pxp-agent has an established connection to a pxp broker"
+pe_status_check::S0043: "S0043 Determines if the console certificate is expiring within 90 days"
 pe_status_check::AS001: "AS001 Determines if the agent host certificate is expiring within 90 days"
 pe_status_check::AS002: "AS002 Determines if the pxp-agent has an established connection to a pxp broker"
 pe_status_check::AS003: "AS003 Determines the certname configuration parameter is incorrectly set outside of the [main] section of the puppet.conf file"

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -496,4 +496,17 @@ Facter.add(:pe_status_check, type: :aggregate) do
     Facter.debug(e.backtrace)
     { S0042: false }
   end
+
+  chunk(:S0043) do
+    # Is the console cert expiring in the next 90 days (skips if not in default location)
+     next unless ['primary', 'legacy_primary'].include?(Facter.value('pe_status_check_role'))
+    next unless File.exists?('/opt/puppetlabs/server/data/console-services/certs/console-cert.cert.pem')
+    consolecert = '/opt/puppetlabs/server/data/console-services/certs/console-cert.cert.pem'
+    raw_consolecert = File.read(consolecert)
+     certificate = OpenSSL::X509::Certificate.new raw_consolecert
+    result = certificate.not_after - Time.now
+
+    { S0043: result > 7_776_000 }
+  end
+
 end


### PR DESCRIPTION
this commit checks the default location of the console cert and does the usual expiration check:

Flaws with this method:

console cert file may be present and not in use resulting in false readings

does not work if custom cert location exists