### PR TITLE
(#172) Improve query time on S0026

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -297,9 +297,9 @@ Facter.add(:pe_status_check, type: :aggregate) do
   chunk(:S0026) do
     next unless ['primary', 'legacy_primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
 
-    response = PEStatusCheck.http_get('/status/v1/services?level=debug', 8140)
+    response = PEStatusCheck.http_get('/status/v1/services/status-service?level=debug', 8140)
     if response
-      heap_max = response.dig('status-service', 'status', 'experimental', 'jvm-metrics', 'heap-memory', 'init')
+      heap_max = response.dig('status', 'experimental', 'jvm-metrics', 'heap-memory', 'init')
       {
         S0026: if heap_max.nil?
                  false


### PR DESCRIPTION
Specifying the 'status-service' endpoint in the URL path to narrow the status scope significantly decreases the query time on large PE environments to avoid hitting the 2 second request timeout.

## Please check off the steps below as you complete each step
- [x] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [x] Update the Jira ticket status to `Ready for Review` if there is one
- [x] Review any CI failures and fix issues
