### PR TITLE
(SUP-3777) Stop loop in S0039 if log is in unreadable format

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -464,10 +464,10 @@ Facter.add(:pe_status_check, type: :aggregate) do
       current = since_lastrun.to_i <= Puppet.settings['runinterval']
 
       match[:status] == '503' and current
-      rescue StandardError => e
-        Facter.warn("Error in fact 'pe_status_check.S0039' when querying puppetserver access logs: #{e.message}")
-        Facter.debug(e.backtrace)
-        break
+    rescue StandardError => e
+      Facter.warn("Error in fact 'pe_status_check.S0039' when querying puppetserver access logs: #{e.message}")
+      Facter.debug(e.backtrace)
+      break
     end
 
     { S0039: !has_503 }

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -464,9 +464,10 @@ Facter.add(:pe_status_check, type: :aggregate) do
       current = since_lastrun.to_i <= Puppet.settings['runinterval']
 
       match[:status] == '503' and current
-    rescue StandardError => e
-      Facter.warn("Error in fact 'pe_status_check.S0039' when querying puppetserver access logs: #{e.message}")
-      Facter.debug(e.backtrace)
+      rescue StandardError => e
+        Facter.warn("Error in fact 'pe_status_check.S0039' when querying puppetserver access logs: #{e.message}")
+        Facter.debug(e.backtrace)
+        break
     end
 
     { S0039: !has_503 }


### PR DESCRIPTION
## Please check off the steps below as you complete each step
- [x] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [x] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues

Adds a break to the rescue statement in the loop in S0039 so if the time is in a unreadable format we only show the warning once instead of for every line it occurs. 