### PR TITLE
Enable security cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -373,8 +373,6 @@ RSpec/VoidExpect:
   Enabled: false
 RSpec/Yield:
   Enabled: false
-Security/Open:
-  Enabled: false
 Style/AccessModifierDeclarations:
   Enabled: false
 Style/AccessorGrouping:
@@ -628,10 +626,6 @@ RSpec/SortMetadata:
 RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
-  Enabled: false
-Security/CompoundHash:
-  Enabled: false
-Security/IoMethods:
   Enabled: false
 Style/ArgumentsForwarding:
   Enabled: false

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -431,7 +431,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
 
   chunk(:S0036) do
     next unless ['primary', 'legacy_primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
-    str = IO.read('/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf')
+    str = File.read('/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf')
     max_queued_requests = str.match(%r{max-queued-requests: (\d+)})
     if max_queued_requests.nil?
       { S0036: true }


### PR DESCRIPTION
IO.read is potentially unsafe when called with special characters, which isn't an issue here. Use File.read to avoid any future issues.

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
