### PR TITLE
(SUP-3709) - Indicator Exclusion using code manager and Hiera lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,20 @@ plan_hierarchy:
     data_hash: yaml_data
 ```
 
+
 See the following [documentation](https://puppet.com/docs/bolt/latest/hiera.html#outside-apply-blocks) for further explanation.
+
+#### Using Static Hiera data to populate indicator_exclusions when executing plans
+
+Place the plan_hierarchy listed in the step above, in the environment layer (https://www.puppet.com/docs/pe/latest/writing_plans_in_puppet_language_pe.html#using_hiera_with_plans)
+
+Create a [static.yaml] file in the environment layer hiera data directory```
+```yaml
+pe_status_check::indicator_exclusions:                                             
+  - '<TEST ID>'                                                                
+``` 
+
+Indicator ID's within array will be excluded when `running pe_status_check::infra_summary` and `pe_status_check::agent_summary` p
 
 #### Running the plans
 

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -23,3 +23,4 @@ hierarchy:
 plan_hierarchy:
   - name: "Static data"
     path: "static.yaml"
+    data_hash: yaml_data

--- a/plans/agent_summary.pp
+++ b/plans/agent_summary.pp
@@ -6,8 +6,9 @@
 #   Defaults to using a PuppetDB query to identify nodes
 # @param indicator_exclusions
 #   List of disabled indicators, place any indicator ids you do not wish to report on in this list
+#   Static Hiera Data can be used to set indicator_exclusions in a plan - for more information see https://www.puppet.com/docs/pe/latest/writing_plans_in_puppet_language_pe.html#using_hiera_with_plans 
 plan pe_status_check::agent_summary(
-  Array[String[1]] $indicator_exclusions = [],
+  Array[String[1]] $indicator_exclusions = lookup('pe_status_check::indicator_exclusions', undef, undef, []),
   Optional[TargetSpec] $targets          = undef,
 ) {
   # Query PuppetDB if $targets is not unspecified

--- a/plans/infra_summary.pp
+++ b/plans/infra_summary.pp
@@ -6,8 +6,9 @@
 #   Defaults to using a PuppetDB query to identify nodes
 # @param indicator_exclusions
 #   List of disabled indicators, place any indicator ids you do not wish to report on in this list
+#   Static Hiera Data can be used to set indicator_exclusions in a plan - for more information see https://www.puppet.com/docs/pe/latest/writing_plans_in_puppet_language_pe.html#using_hiera_with_plans 
 plan pe_status_check::infra_summary(
-  Array[String[1]] $indicator_exclusions = [],
+  Array[String[1]] $indicator_exclusions = lookup('pe_status_check::indicator_exclusions', undef, undef, []),
   Optional[TargetSpec] $targets          = undef,
 ) {
   # Query PuppetDB if $targets is not unspecified


### PR DESCRIPTION
Work done and tested within PE_Status_Check, lookup added to `pe_status_check::infra_summary` and `pe_status_check::agent_summary` plans and tested within PE_Console