### PR TITLE
(SUP-4714) Check if logfile exists during runtime of S0039

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -478,6 +478,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
     next unless ['primary', 'legacy_primary', 'replica', 'pe_compiler', 'legacy_compiler'].include?(Facter.value('pe_status_check_role'))
 
     logfile = File.dirname(Puppet.settings['logdir'].to_s) + '/puppetserver/puppetserver-access.log'
+    next unless File.exist?(logfile)
     apache_regex = %r{^(\S+) \S+ (\S+) (?<time>\[([^\]]+)\]) "([A-Z]+) ([^ "]+)? HTTP/[0-9.]+" (?<status>[0-9]{3})}
 
     has_503 = File.foreach(logfile).any? do |line|


### PR DESCRIPTION
S0039 Indicator was producing an error when there was no existing `puppetserver-access.log` file located within `/var/log/puppetlabs/puppetserver`.

This PR resolves the error messages being highlighted by https://github.com/puppetlabs/puppetlabs-pe_status_check/issues/213 - adding in a condition that will bypass the indicator in the event of a non existent file. 