### PR TITLE
(SUP-4990) S0039 Accommodate parsing of unicode dates in September

### DIFF
--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -493,8 +493,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
     has_503 = File.foreach(logfile).any? do |line|
       match = line.match(apache_regex)
       next unless match && match[:time] && match[:status]
-
-      time = Time.strptime(match[:time], '[%d/%b/%Y:%H:%M:%S %Z]')
+      time = Time.strptime(match[:time].gsub('Sept', 'Sep'), '[%d/%b/%Y:%H:%M:%S %Z]')
       since_lastrun = Time.now - time
       current = since_lastrun.to_i <= Puppet.settings['runinterval']
 


### PR DESCRIPTION
Add string substitution to S0039 to accommodate unicode CLDR change from Sep to Sept for %b in September

## Please check off the steps below as you complete each step
- [x] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [x] Review any CI failures and fix issues
