### PR TITLE
(#236) agent_state_summary: Check if cached_catalog_status is null

### DIFF
--- a/plans/agent_state_summary.pp
+++ b/plans/agent_state_summary.pp
@@ -36,7 +36,8 @@ plan pe_status_check::agent_state_summary (
   $corrective_changes = $nodes.map |$node| { if ($node['latest_report_corrective_change'] == true){ $node['certname'] } }.filter |$node| { $node =~ NotUndef }
 
   # all nodes that used a cached catalog on the last run
-  $used_cached_catalog = $nodes.map |$node| { if ($node['cached_catalog_status'] != 'not_used'){ $node['certname'] } }.filter |$node| { $node =~ NotUndef }
+  # explicitly check if `cached_catalog_status` is set, will be null on nodes without a catalog
+  $used_cached_catalog = $nodes.map |$node| { if ($node['cached_catalog_status'] and $node['cached_catalog_status'] != 'not_used'){ $node['certname'] } }.filter |$node| { $node =~ NotUndef }
 
   # all nodes with failed resources in the last report
   $failed = $nodes.map |$node| { if ($node['latest_report_status'] == 'failed'){ $node['certname'] } }.filter |$node| { $node =~ NotUndef }


### PR DESCRIPTION
The attribute `cached_catalog_status` on the `/nodes` endpoint will be `null` for nodes without a catalog in PuppetDB:

```
puppet query 'nodes[certname,latest_report_noop,latest_report_corrective_change,cached_catalog_status,latest_report_status,report_timestamp]{}'
```

```
[
  {
    "cached_catalog_status": null,
    "certname": "pe2.tim.betadots.training",
    "latest_report_corrective_change": null,
    "latest_report_noop": null,
    "latest_report_status": null,
    "report_timestamp": null
  }
]
```

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
