### PR TITLE
(#236) agent_state_summary: Count nodes without report as unhealthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The plan `pe_status_check::agent_state_summary` provides you a hash with all nod
   "failed": [ ],
   "changed": [ "student2.local" ],
   "unresponsive": [ "student3.local", "student4.local", "student1.local", "login.local" ],
+  "no_report": [ "newnode.with.report.local" ],
   "responsive": [ "pe.bastelfreak.local"],
   "unhealthy": [ "student2.local", "student3.local", "student4.local", "student1.local", "login.local" ],
   "unhealthy_counter": 5,
@@ -181,6 +182,7 @@ The plan `pe_status_check::agent_state_summary` provides you a hash with all nod
 * `failed`: The last catalog couldn't be compiled or catalog application raised an error
 * `changed`: A node reported a change
 * `unresponsive`: Last report is older than 30 minutes (can be configured via the `runinterval` parameter)
+* `no_report`: The node exists in PuppetDB but has no reports
 * `corrective_changes`: A node reported corrective changes
 * `used_cached_catalog`: The node didn't apply a new catalog but used a cached version
 * `unhealthy`: List of nodes that are in any of the above categories


### PR DESCRIPTION
It's possible that a Puppet Agent was stopped or disabled and all old reports were garbage collected from PuppetDB. The node still exists in PuppetDB, but when checking for a report the timestamp is null:

```
puppet query nodes[certname,report_timestamp]{}
```

```json
[
  {
    "certname": "pe.tim.local",
    "report_timestamp": "2024-09-30T13:21:17.042Z"
  },
  {
    "certname": "pe2.tim.local",
    "report_timestamp": null
  }
]
```

Previously we always assumed that `report_timestamp` has a valid timestamp. With this patch we explicitly validate the timestamp and count nodes withhout a timestamp as unhealthy.

Now with the fix:

```
puppet plan run pe_status_check::agent_state_summary --environment peadm log_healthy_nodes=true log_unhealthy_nodes=true
```

```json
{
    "responsive": [
        "pe.tim.local",
        "pe2.tim.local"
    ],
    "healthy_counter": 0,
    "total_counter": 2,
    "unhealthy_counter": 2,
    "noop": [],
    "unhealthy": [
        "pe2.tim.local",
        "pe.tim.local"
    ],
    "healthy": [],
    "changed": [
        "pe.tim.local"
    ],
    "no_report": [
        "pe.tim.local"
    ],
    "corrective_changes": [],
    "used_cached_catalog": [
        "pe2.tim.local"
    ],
    "unresponsive": [],
    "failed": []
}
```

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
