### PR TITLE
fix: prevent random failures in agent_status_check

### DIFF
--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -31,7 +31,11 @@ Facter.add(:agent_status_check, type: :aggregate) do
       socket_matches = Set.new(socket_state.scan(%r{ino:(\d+)}).flatten)
 
       # Look for the pxp-agent process in the process table:
-      cmdline_path = Dir.glob('/proc/[0-9]*/cmdline').find { |path| File.read(path).split("\0").first == '/opt/puppetlabs/puppet/bin/pxp-agent' }
+      cmdline_path = Dir.glob('/proc/[0-9]*/cmdline').find do |path|
+        File.read(path).split("\0").first == '/opt/puppetlabs/puppet/bin/pxp-agent'
+      rescue Errno::ENOENT
+        next
+      end
 
       # If no match was found, then the connection to 8142 is not the pxp-agent process because it is not in the process table:
       if cmdline_path.nil?


### PR DESCRIPTION
The list of files in /proc/[0-9]*/cmdline can change as processes start or terminate between the Dir.glob and File.read operations

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
