### PR TITLE
(PUPSUP-86) Update S0015 and AS001

### DIFF
--- a/lib/facter/agent_status_check.rb
+++ b/lib/facter/agent_status_check.rb
@@ -1,6 +1,6 @@
 # Agent Status Check fact aims to have all chunks reporting as true, indicating ideal state, any individual chunk reporting false should be alerted on and checked against documentation for next steps
 # Use shared logic from PEStatusCheck
-# Disabled by default requires bundled class too create /opt/puppetlabs/puppet/cache/status_check_enable
+# Disabled by default requires bundled class to create /opt/puppetlabs/puppet/cache/status_check_enable
 
 Facter.add(:agent_status_check, type: :aggregate) do
   confine { !Facter.value(:pe_build) }
@@ -15,7 +15,7 @@ Facter.add(:agent_status_check, type: :aggregate) do
     certificate = OpenSSL::X509::Certificate.new raw_hostcert
     result = certificate.not_after - Time.now
 
-    { AS001: result > 7_776_000 }
+    { AS001: result > 2_592_000 }
   end
   chunk(:AS002) do
     # Has the PXP agent establish a connection with a remote Broker

--- a/lib/facter/pe_status_check.rb
+++ b/lib/facter/pe_status_check.rb
@@ -142,7 +142,7 @@ Facter.add(:pe_status_check, type: :aggregate) do
     certificate = OpenSSL::X509::Certificate.new raw_hostcert
     result = certificate.not_after - Time.now
 
-    { S0015: result > 7_776_000 }
+    { S0015: result > 2_592_000 }
   end
 
   chunk(:S0016) do


### PR DESCRIPTION
This commit reduces the threshold to flag S0015 and AS001 as false from 90 days to 30 days. This change was made since in PE 2023.4 certificate
   auto renewal is enabled and new certs having a validity of 90 days.
Therefore, this avoids the indicators perpetually being in a false state. Also this commit fixes a typo changing 'too' to 'to' for gramatical clarity in agent_status_check.rb. No tests needed to be changed for these indicators.

## Please check off the steps below as you complete each step
- [x] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [x] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
